### PR TITLE
IngressのAPIをnetworking.k8s.io/v1に変更する

### DIFF
--- a/delivery/manifest/eks/ingress/pxr-ingress.yaml
+++ b/delivery/manifest/eks/ingress/pxr-ingress.yaml
@@ -37,7 +37,7 @@ spec:
   - host: application000001.domain.com
     http:
       paths:
-      - path: /*
+      - path: /
         pathType: Prefix
         backend:
           service:
@@ -47,7 +47,7 @@ spec:
   - host: region000001.domain.com
     http:
       paths:
-      - path: /*
+      - path: /
         pathType: Prefix
         backend:
           service:
@@ -57,7 +57,7 @@ spec:
   - host: root.domain.com
     http:
       paths:
-      - path: /*
+      - path: /
         pathType: Prefix
         backend:
           service:

--- a/delivery/manifest/eks/ingress/pxr-ingress.yaml
+++ b/delivery/manifest/eks/ingress/pxr-ingress.yaml
@@ -17,7 +17,7 @@
 #
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -38,21 +38,30 @@ spec:
     http:
       paths:
       - path: /*
+        pathType: Prefix
         backend:
-          serviceName: application000001-service
-          servicePort: 80
+          service:
+            name: application000001-service
+            port:
+              number: 80
   - host: region000001.domain.com
     http:
       paths:
       - path: /*
+        pathType: Prefix
         backend:
-          serviceName: region000001-service
-          servicePort: 80
+          service:
+            name: region000001-service
+            port:
+              number: 80
   - host: root.domain.com
     http:
       paths:
       - path: /*
+        pathType: Prefix
         backend:
-          serviceName: root-service
-          servicePort: 80
+          service:
+            name: root-service
+            port:
+              number: 80
  


### PR DESCRIPTION
fix #3 
* IngressのAPIを `extensions/v1beta1` から `networking.k8s.io/v1` へ変更し、manifestの記述も`networking.k8s.io/v1` の仕様に適合させる。